### PR TITLE
feat: Octokit 導入と GitHub 連携基盤を追加（依存追加、repo 情報取得ユーティリティと CLI 統合）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/rest": "latest",
         "commander": "latest"
       },
       "bin": {
@@ -522,6 +523,160 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.5.tgz",
+      "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.2",
+        "@octokit/request": "^10.0.4",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.1.tgz",
+      "integrity": "sha512-7P1dRAZxuWAOPI7kXfio88trNi/MegQ0IJD3vfgC3b+LZo1Qe6gRJc2v0mz2USWWJOKrB2h5spXCzGbw+fAdqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^15.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.2.tgz",
+      "integrity": "sha512-iz6KzZ7u95Fzy9Nt2L8cG88lGRMr/qy1Q36ih/XVzMIlPDMYwaNLE/ENhqmIzgPrlNWiYJkwmveEetvxAgFBJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.4",
+        "@octokit/types": "^15.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+      "integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.2.1.tgz",
+      "integrity": "sha512-Tj4PkZyIL6eBMYcG/76QGsedF0+dWVeLhYprTmuFVVxzDW7PQh23tM0TP0z+1MvSkxB29YFZwnUX+cXfTiSdyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^15.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.1.1.tgz",
+      "integrity": "sha512-VztDkhM0ketQYSh5Im3IcKWFZl7VIrrsCaHbDINkdYeiiAsJzjhS2xRFCSJgfN6VOcsoW4laMtsmf3HcNqIimg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^15.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.5.tgz",
+      "integrity": "sha512-TXnouHIYLtgDhKo+N6mXATnDBkV05VwbR0TtMWpgTHIoQdRQfCSzmy/LGqR1AbRMbijq/EckC/E3/ZNcU92NaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.1",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.1.tgz",
+      "integrity": "sha512-CZpFwV4+1uBrxu7Cw8E5NCXDWFNf18MSY23TdxCBgjw1tXXHvTrZVsXlW8hgFTOLw8RQR1BBrMvYRtuyaijHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^15.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.0.tgz",
+      "integrity": "sha512-z6tmTu9BTnw51jYGulxrlernpsQYXpui1RK21vmXn8yF5bp6iX16yfTtJYGK5Mh1qDkvDOmp2n8sRMcQmR8jiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.2",
+        "@octokit/plugin-paginate-rest": "^13.0.1",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.1.tgz",
+      "integrity": "sha512-sdiirM93IYJ9ODDCBgmRPIboLbSkpLa5i+WLuXH8b8Atg+YMLAyLvDDhNWLV4OYd08tlvYfVm/dw88cqHWtw1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^26.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -911,6 +1066,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1097,6 +1258,22 @@
         "@esbuild/win32-ia32": "0.25.11",
         "@esbuild/win32-x64": "0.25.11"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1889,6 +2066,12 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@octokit/rest": "latest",
     "commander": "latest"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { readFileAsBase64, FileReadError } from "./utils/fileReader.js";
+import { getRepoInfo, GitHubError } from "./utils/github.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -38,14 +39,24 @@ program
         `📦 Content size: ${fileContent.content.length} bytes (base64)`
       );
 
+      // GitHub API連携
+      console.log("\n🔗 Connecting to GitHub...");
+      const repoInfo = await getRepoInfo(repo);
+      console.log(`✅ Repository: ${repoInfo.fullName}`);
+      console.log(`🌿 Default branch: ${repoInfo.defaultBranch}`);
+
       if (options.path) {
         console.log(`📍 Destination: ${options.path}`);
       }
 
-      console.log("\n⚠️  GitHub API integration coming soon...");
+      console.log("\n⚠️  Branch creation and PR coming soon...");
     } catch (error) {
       if (error instanceof FileReadError) {
-        console.error(`\n❌ Error: ${error.message}`);
+        console.error(`\n❌ File Error: ${error.message}`);
+        process.exit(1);
+      }
+      if (error instanceof GitHubError) {
+        console.error(`\n❌ GitHub Error: ${error.message}`);
         process.exit(1);
       }
       throw error;

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,0 +1,88 @@
+import { Octokit } from "@octokit/rest";
+
+export interface RepoInfo {
+  owner: string;
+  repo: string;
+  defaultBranch: string;
+  fullName: string;
+}
+
+export class GitHubError extends Error {
+  constructor(message: string, public readonly code?: string) {
+    super(message);
+    this.name = "GitHubError";
+  }
+}
+
+/**
+ * リポジトリURLをパースする（owner/repo形式）
+ */
+export function parseRepoUrl(repoUrl: string): { owner: string; repo: string } {
+  const match = repoUrl.match(/^([^/]+)\/([^/]+)$/);
+  if (!match) {
+    throw new GitHubError(
+      `Invalid repository format: ${repoUrl}. Expected format: owner/repo`
+    );
+  }
+  return { owner: match[1], repo: match[2] };
+}
+
+/**
+ * GitHub Personal Access Tokenを取得する
+ */
+export function getGitHubToken(): string {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new GitHubError(
+      "GitHub token not found. Please set GITHUB_TOKEN environment variable."
+    );
+  }
+  return token;
+}
+
+/**
+ * Octokitクライアントを作成する
+ */
+export function createOctokitClient(token: string): Octokit {
+  return new Octokit({ auth: token });
+}
+
+/**
+ * リポジトリ情報を取得する
+ */
+export async function getRepoInfo(repoUrl: string): Promise<RepoInfo> {
+  const { owner, repo } = parseRepoUrl(repoUrl);
+  const token = getGitHubToken();
+  const octokit = createOctokitClient(token);
+
+  try {
+    const { data } = await octokit.rest.repos.get({
+      owner,
+      repo,
+    });
+
+    return {
+      owner,
+      repo,
+      defaultBranch: data.default_branch,
+      fullName: data.full_name,
+    };
+  } catch (error: any) {
+    if (error.status === 401) {
+      throw new GitHubError(
+        "Authentication failed. Please check your GITHUB_TOKEN.",
+        "AUTH_FAILED"
+      );
+    }
+    if (error.status === 404) {
+      throw new GitHubError(
+        `Repository not found: ${owner}/${repo}`,
+        "REPO_NOT_FOUND"
+      );
+    }
+    throw new GitHubError(
+      `Failed to fetch repository info: ${error.message}`,
+      "API_ERROR"
+    );
+  }
+}


### PR DESCRIPTION
- package.json に @octokit/rest を追加（package-lock.json 更新）
- 新規: src/utils/github.ts を追加（トークン取得、Octokit クライアント生成、リポジトリ情報取得、GitHubError 定義）
- src/index.ts の fire コマンドで getRepoInfo を呼び出し GitHub への接続ログを表示
- エラーハンドリングを強化（FileReadError, GitHubError の区別と終了コード）