### PR TITLE
feat: ブランチ作成とファイルコミット機能を追加し CLI に統合

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,12 @@ import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { readFileAsBase64, FileReadError } from "./utils/fileReader.js";
-import { getRepoInfo, GitHubError } from "./utils/github.js";
+import {
+  getRepoInfo,
+  GitHubError,
+  createBranchWithFile,
+} from "./utils/github.js";
+import { basename } from "path";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -45,11 +50,28 @@ program
       console.log(`✅ Repository: ${repoInfo.fullName}`);
       console.log(`🌿 Default branch: ${repoInfo.defaultBranch}`);
 
-      if (options.path) {
-        console.log(`📍 Destination: ${options.path}`);
-      }
+      // 送信先パスを決定
+      const destinationPath = options.path || basename(file);
+      console.log(`📍 Destination: ${destinationPath}`);
 
-      console.log("\n⚠️  Branch creation and PR coming soon...");
+      // ファイルをBase64デコードしてコミット
+      const decodedContent = Buffer.from(
+        fileContent.content,
+        "base64"
+      ).toString("utf-8");
+
+      console.log("\n🌿 Creating branch and committing file...");
+      const { branchName, commitSha } = await createBranchWithFile(
+        repo,
+        file,
+        decodedContent,
+        destinationPath
+      );
+
+      console.log(`✅ Branch created: ${branchName}`);
+      console.log(`✅ Commit created: ${commitSha.substring(0, 7)}`);
+
+      console.log("\n⚠️  PR creation coming soon...");
     } catch (error) {
       if (error instanceof FileReadError) {
         console.error(`\n❌ File Error: ${error.message}`);

--- a/test-commit.md
+++ b/test-commit.md
@@ -1,0 +1,19 @@
+# Test File for PR Cannon
+
+This is a test file created to verify the branch creation and commit functionality of pr-cannon.
+
+## Features Tested
+
+- File reading and Base64 encoding
+- GitHub API integration
+- Branch creation
+- File commit
+- PR creation (coming soon)
+
+## Timestamp
+
+Created at: $(date)
+
+## Author
+
+PR Cannon Test Suite


### PR DESCRIPTION
utils/github に generateBranchName と createBranchWithFile を実装し、 CLI の fire コマンドから Base64 デコード → destination path 決定 → ブランチ作成・コミットを実行するよう統合。 実行ログを追加し、手動テスト用の test-commit.md を追加。